### PR TITLE
Optional Repo with qemu-ev linked against GlusterFS 3.4

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -3,3 +3,10 @@ suites:
   - name: default
     run_list:
       - recipe[yum-qemu-ev::default]
+  - name: glusterfs_34
+    run_list:
+      - recipe[yum-qemu-ev::default]
+    attributes:
+      yum:
+        qemu-ev-attr:
+          glusterfs_34: true

--- a/Berksfile
+++ b/Berksfile
@@ -1,3 +1,5 @@
 source 'https://supermarket.chef.io'
 
+cookbook 'base', git: 'git@github.com:osuosl-cookbooks/base'
+
 metadata

--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@ default['yum']['qemu-ev']['baseurl'] = 'http://ftp.osuosl.org/pub/osl/repos/yum/
 # x86_64 defaults
 default['yum']['qemu-ev']['gpgkey'] = 'file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-SIG-Virtualization'
 default['yum']['qemu-ev']['baseurl'] = 'http://centos.osuosl.org/$releasever/virt/$basearch/kvm-common/'
+# Use special yum repo that has qemu-ev linked against GlusterFS 3.4
+default['yum']['qemu-ev-attr']['glusterfs_34'] = false
 ```
 
 Usage

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -2,6 +2,7 @@ default['yum']['qemu-ev']['repositoryid'] = 'qemu-ev'
 default['yum']['qemu-ev']['description'] = 'QEMU EV'
 default['yum']['qemu-ev']['enabled'] = true
 default['yum']['qemu-ev']['gpgcheck'] = true
+default['yum']['qemu-ev-attr']['glusterfs_34'] = false
 case node['kernel']['machine']
 when 'ppc64', 'ppc64le'
   default['yum']['qemu-ev']['gpgkey'] = 'http://ftp.osuosl.org/pub/osl/repos/yum/RPM-GPG-KEY-osuosl'
@@ -9,4 +10,9 @@ when 'ppc64', 'ppc64le'
 when 'x86_64'
   default['yum']['qemu-ev']['gpgkey'] = 'file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-SIG-Virtualization'
   default['yum']['qemu-ev']['baseurl'] = 'http://centos.osuosl.org/$releasever/virt/$basearch/kvm-common/'
+end
+if node['yum']['qemu-ev-attr']['glusterfs_34'] &&
+   node['kernel']['machine'] == 'x86_64'
+  default['yum']['qemu-ev']['gpgkey'] = 'http://ftp.osuosl.org/pub/osl/repos/yum/RPM-GPG-KEY-osuosl'
+  default['yum']['qemu-ev']['baseurl'] = 'http://ftp.osuosl.org/pub/osl/repos/yum/$releasever/RHEV-glusterfs-34/$basearch'
 end

--- a/metadata.rb
+++ b/metadata.rb
@@ -8,6 +8,7 @@ description      'Installs/Configures yum-qemu-ev'
 long_description 'Installs/Configures yum-qemu-ev'
 version          '1.0.1'
 
+depends          'base'
 depends          'yum'
 
 supports         'centos', '~> 7.0'

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -16,9 +16,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+if node['yum']['qemu-ev-attr']['glusterfs_34'] &&
+   node['kernel']['machine'] == 'x86_64'
+  include_recipe 'base::glusterfs'
+end
+
 # Install Virt SIG gpg repo key
 package 'centos-release-virt-common' do
-  only_if { node['kernel']['machine'] == 'x86_64' }
+  only_if do
+    node['kernel']['machine'] == 'x86_64' &&
+      !node['yum']['qemu-ev-attr']['glusterfs_34']
+  end
 end
 
 yum_repository 'qemu-ev' do

--- a/spec/default_spec.rb
+++ b/spec/default_spec.rb
@@ -20,6 +20,32 @@ describe 'yum-qemu-ev::default' do
         baseurl: 'http://centos.osuosl.org/$releasever/virt/$basearch/kvm-common/'
       )
   end
+  it 'Does not include base::glusterfs' do
+    expect(chef_run).to_not include_recipe('base::glusterfs')
+  end
+  context 'enabling glusterfs_34 attribute' do
+    cached(:chef_run) do
+      ChefSpec::SoloRunner.new(CENTOS_7_OPTS) do |node|
+        node.set['yum']['qemu-ev-attr']['glusterfs_34'] = true
+      end.converge(described_recipe)
+    end
+    it 'Does not install centos-release-virt-common' do
+      expect(chef_run).to_not install_package('centos-release-virt-common')
+    end
+    it 'Includes base::glusterfs' do
+      expect(chef_run).to include_recipe('base::glusterfs')
+    end
+    it 'creates qemu-ev yum repository' do
+      expect(chef_run).to create_yum_repository('qemu-ev')
+        .with(
+          description: 'QEMU EV',
+          enabled: true,
+          gpgcheck: true,
+          gpgkey: 'http://ftp.osuosl.org/pub/osl/repos/yum/RPM-GPG-KEY-osuosl',
+          baseurl: 'http://ftp.osuosl.org/pub/osl/repos/yum/$releasever/RHEV-glusterfs-34/$basearch'
+        )
+    end
+  end
   %w(ppc64 ppc64le).each do |a|
     context "setting arch to #{a}" do
       cached(:chef_run) do
@@ -39,6 +65,27 @@ describe 'yum-qemu-ev::default' do
             gpgkey: 'http://ftp.osuosl.org/pub/osl/repos/yum/RPM-GPG-KEY-osuosl',
             baseurl: 'http://ftp.osuosl.org/pub/osl/repos/yum/openpower/centos-$releasever/$basearch/RHEV'
           )
+      end
+      context 'enabling glusterfs_34 attribute' do
+        cached(:chef_run) do
+          ChefSpec::SoloRunner.new(CENTOS_7_OPTS) do |node|
+            node.automatic['kernel']['machine'] = a
+            node.set['yum']['qemu-ev-attr']['glusterfs_34'] = true
+          end.converge(described_recipe)
+        end
+        it 'Does not include base::glusterfs' do
+          expect(chef_run).to_not include_recipe('base::glusterfs')
+        end
+        it 'Creates qemu-ev yum repository without Gluster 3.4' do
+          expect(chef_run).to create_yum_repository('qemu-ev')
+            .with(
+              description: 'QEMU EV',
+              enabled: true,
+              gpgcheck: true,
+              gpgkey: 'http://ftp.osuosl.org/pub/osl/repos/yum/RPM-GPG-KEY-osuosl',
+              baseurl: 'http://ftp.osuosl.org/pub/osl/repos/yum/openpower/centos-$releasever/$basearch/RHEV'
+            )
+        end
       end
     end
   end

--- a/test/integration/glusterfs_34/serverspec/server_spec.rb
+++ b/test/integration/glusterfs_34/serverspec/server_spec.rb
@@ -23,14 +23,7 @@ describe command('/usr/libexec/qemu-kvm --version') do
   its(:stdout) { should match(/#{qemu_pkg}/) }
 end
 
-# Ensure this package was installed using the correct key
-case os[:arch]
-when 'x86_64'
-  describe command('rpm -qi qemu-kvm-ev | grep Signature') do
-    its(:stdout) { should_not match(/Key ID 2df30655a70b13b7/) }
-  end
-when 'ppc64', 'ppc64le'
-  describe command('rpm -qi qemu-kvm-ev | grep Signature') do
-    its(:stdout) { should match(/Key ID 2df30655a70b13b7/) }
-  end
+# Ensure this package was installed using our gpg key
+describe command('rpm -qi qemu-kvm-ev | grep Signature') do
+  its(:stdout) { should match(/Key ID 2df30655a70b13b7/) }
 end


### PR DESCRIPTION
Since we're still using GlusterFS 3.4 in production, we need to build our own
version of qemu-ev that's linked against that version. Otherwise the yum will
fail when installing cinder packages on the controller node.

This is needed for osuosl-cookbooks/osl-openstack#35.

@osuosl-cookbooks/chefs please review
