### PR TITLE
Exclude qemu* packages from centos repos

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -10,5 +10,6 @@ version          '1.1.1'
 
 depends          'base'
 depends          'yum'
+depends          'yum-centos'
 
 supports         'centos', '~> 7.0'

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -35,6 +35,16 @@ package 'centos-release-virt-common' do
   end
 end
 
+include_recipe 'yum-centos'
+
+# Exclude all qemu packages from the CentOS repos
+node['yum-centos']['repos'].each do |repo|
+  next unless node['yum'][repo]['managed']
+  r = resources(yum_repository: repo)
+  # If we already have excludes, include them and append qemu
+  r.exclude = [r.exclude, 'qemu*'].reject(&:nil?).join(' ')
+end
+
 yum_repository 'qemu-ev' do
   node['yum']['qemu-ev'].each do |key, value|
     send(key.to_sym, value)

--- a/spec/default_spec.rb
+++ b/spec/default_spec.rb
@@ -10,6 +10,15 @@ describe 'yum-qemu-ev::default' do
   it 'installs centos-release-virt-common' do
     expect(chef_run).to install_package('centos-release-virt-common')
   end
+
+  it 'Excludes qemu* from CentOS repos' do
+    chef_run.node['yum-centos']['repos'].each do |repo|
+      next unless chef_run.node['yum'][repo]['managed']
+      expect(chef_run).to create_yum_repository(repo)
+        .with(exclude: 'qemu*')
+    end
+  end
+
   it 'creates qemu-ev yum repository' do
     expect(chef_run).to create_yum_repository('qemu-ev')
       .with(

--- a/test/integration/default/serverspec/server_spec.rb
+++ b/test/integration/default/serverspec/server_spec.rb
@@ -34,3 +34,9 @@ when 'ppc64', 'ppc64le'
     its(:stdout) { should match(/Key ID 2df30655a70b13b7/) }
   end
 end
+
+%w(base extras updates).each do |r|
+  describe file("/etc/yum.repos.d/#{r}.repo") do
+    its(:content) { should match(/^exclude=qemu\*$/) }
+  end
+end


### PR DESCRIPTION
This is to ensure we don't accidentally upgrade to something included in the
upstream repo vs. what's in the RHEV repo.