### PR TITLE
Exclude seabios* packages from upstream repos

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -42,7 +42,7 @@ node['yum-centos']['repos'].each do |repo|
   next unless node['yum'][repo]['managed']
   r = resources(yum_repository: repo)
   # If we already have excludes, include them and append qemu
-  r.exclude = [r.exclude, 'qemu*'].reject(&:nil?).join(' ')
+  r.exclude = [r.exclude, 'qemu* seabios*'].reject(&:nil?).join(' ')
 end
 
 yum_repository 'qemu-ev' do

--- a/spec/default_spec.rb
+++ b/spec/default_spec.rb
@@ -15,7 +15,7 @@ describe 'yum-qemu-ev::default' do
     chef_run.node['yum-centos']['repos'].each do |repo|
       next unless chef_run.node['yum'][repo]['managed']
       expect(chef_run).to create_yum_repository(repo)
-        .with(exclude: 'qemu*')
+        .with(exclude: 'qemu* seabios*')
     end
   end
 

--- a/test/integration/default/serverspec/server_spec.rb
+++ b/test/integration/default/serverspec/server_spec.rb
@@ -37,6 +37,6 @@ end
 
 %w(base extras updates).each do |r|
   describe file("/etc/yum.repos.d/#{r}.repo") do
-    its(:content) { should match(/^exclude=qemu\*$/) }
+    its(:content) { should match(/^exclude=qemu\* seabios\*$/) }
   end
 end


### PR DESCRIPTION
It appears the upstream repos contain a newer version which breaks qemu-kvm-ev.