### PR TITLE
Revert "Exclude seabios* packages from upstream repos"

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -42,7 +42,7 @@ node['yum-centos']['repos'].each do |repo|
   next unless node['yum'][repo]['managed']
   r = resources(yum_repository: repo)
   # If we already have excludes, include them and append qemu
-  r.exclude = [r.exclude, 'qemu* seabios*'].reject(&:nil?).join(' ')
+  r.exclude = [r.exclude, 'qemu*'].reject(&:nil?).join(' ')
 end
 
 yum_repository 'qemu-ev' do

--- a/spec/default_spec.rb
+++ b/spec/default_spec.rb
@@ -15,7 +15,7 @@ describe 'yum-qemu-ev::default' do
     chef_run.node['yum-centos']['repos'].each do |repo|
       next unless chef_run.node['yum'][repo]['managed']
       expect(chef_run).to create_yum_repository(repo)
-        .with(exclude: 'qemu* seabios*')
+        .with(exclude: 'qemu*')
     end
   end
 

--- a/test/integration/default/serverspec/server_spec.rb
+++ b/test/integration/default/serverspec/server_spec.rb
@@ -37,6 +37,6 @@ end
 
 %w(base extras updates).each do |r|
   describe file("/etc/yum.repos.d/#{r}.repo") do
-    its(:content) { should match(/^exclude=qemu\* seabios\*$/) }
+    its(:content) { should match(/^exclude=qemu\*$/) }
   end
 end


### PR DESCRIPTION
Upstream finally updated the package and now this is breaking it again.

This reverts commit bcb8a733a5d369ac7b3ccee99362b8e2f053876e.