### PR TITLE
Revert "Switch ppc64le to using upstream builds"

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -3,10 +3,11 @@ default['yum']['qemu-ev']['description'] = 'QEMU EV'
 default['yum']['qemu-ev']['enabled'] = true
 default['yum']['qemu-ev']['gpgcheck'] = true
 default['yum']['qemu-ev-attr']['glusterfs_34'] = false
-default['yum']['qemu-ev']['gpgkey'] = 'file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-SIG-Virtualization'
 case node['kernel']['machine']
 when 'ppc64', 'ppc64le'
-  default['yum']['qemu-ev']['baseurl'] = 'http://centos-altarch.osuosl.org/$releasever/virt/$basearch/kvm-common/'
+  default['yum']['qemu-ev']['gpgkey'] = 'http://ftp.osuosl.org/pub/osl/repos/yum/RPM-GPG-KEY-osuosl'
+  default['yum']['qemu-ev']['baseurl'] = 'http://ftp.osuosl.org/pub/osl/repos/yum/openpower/centos-$releasever/$basearch/RHEV'
 when 'x86_64'
+  default['yum']['qemu-ev']['gpgkey'] = 'file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-SIG-Virtualization'
   default['yum']['qemu-ev']['baseurl'] = 'http://centos.osuosl.org/$releasever/virt/$basearch/kvm-common/'
 end

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -29,7 +29,10 @@ end
 
 # Install Virt SIG gpg repo key
 package 'centos-release-virt-common' do
-  not_if { node['yum']['qemu-ev-attr']['glusterfs_34'] }
+  only_if do
+    node['kernel']['machine'] == 'x86_64' &&
+      !node['yum']['qemu-ev-attr']['glusterfs_34']
+  end
 end
 
 include_recipe 'yum-centos'

--- a/spec/default_spec.rb
+++ b/spec/default_spec.rb
@@ -62,8 +62,8 @@ describe 'yum-qemu-ev::default' do
           node.automatic['kernel']['machine'] = a
         end.converge(described_recipe)
       end
-      it do
-        expect(chef_run).to install_package('centos-release-virt-common')
+      it 'not install centos-release-virt-common' do
+        expect(chef_run).to_not install_package('centos-release-virt-common')
       end
       it 'creates qemu-ev yum repository' do
         expect(chef_run).to create_yum_repository('qemu-ev')
@@ -71,9 +71,30 @@ describe 'yum-qemu-ev::default' do
             description: 'QEMU EV',
             enabled: true,
             gpgcheck: true,
-            gpgkey: 'file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-SIG-Virtualization',
-            baseurl: 'http://centos-altarch.osuosl.org/$releasever/virt/$basearch/kvm-common/'
+            gpgkey: 'http://ftp.osuosl.org/pub/osl/repos/yum/RPM-GPG-KEY-osuosl',
+            baseurl: 'http://ftp.osuosl.org/pub/osl/repos/yum/openpower/centos-$releasever/$basearch/RHEV'
           )
+      end
+      context 'enabling glusterfs_34 attribute' do
+        cached(:chef_run) do
+          ChefSpec::SoloRunner.new(CENTOS_7_OPTS) do |node|
+            node.automatic['kernel']['machine'] = a
+            node.normal['yum']['qemu-ev-attr']['glusterfs_34'] = true
+          end.converge(described_recipe)
+        end
+        it 'Does not include base::glusterfs' do
+          expect(chef_run).to_not include_recipe('base::glusterfs')
+        end
+        it 'Creates qemu-ev yum repository without Gluster 3.4' do
+          expect(chef_run).to create_yum_repository('qemu-ev')
+            .with(
+              description: 'QEMU EV',
+              enabled: true,
+              gpgcheck: true,
+              gpgkey: 'http://ftp.osuosl.org/pub/osl/repos/yum/RPM-GPG-KEY-osuosl',
+              baseurl: 'http://ftp.osuosl.org/pub/osl/repos/yum/openpower/centos-$releasever/$basearch/RHEV'
+            )
+        end
       end
     end
   end

--- a/test/integration/default/serverspec/server_spec.rb
+++ b/test/integration/default/serverspec/server_spec.rb
@@ -11,14 +11,28 @@ describe command('yum install -y qemu-kvm') do
   its(:exit_status) { should eq 0 }
 end
 
+case os[:arch]
+when 'x86_64'
+  qemu_pkg = 'qemu-kvm-ev-2'
+when 'ppc64', 'ppc64le'
+  qemu_pkg = 'qemu-kvm-rhev-2'
+end
+
 describe command('/usr/libexec/qemu-kvm --version') do
   its(:exit_status) { should eq 0 }
-  its(:stdout) { should match(/qemu-kvm-ev-2/) }
+  its(:stdout) { should match(/#{qemu_pkg}/) }
 end
 
 # Ensure this package was installed using the correct key
-describe command('rpm -qi qemu-kvm-ev | grep Signature') do
-  its(:stdout) { should match(/Key ID 7aebbe8261e8806c/) }
+case os[:arch]
+when 'x86_64'
+  describe command('rpm -qi qemu-kvm-ev | grep Signature') do
+    its(:stdout) { should_not match(/Key ID 2df30655a70b13b7/) }
+  end
+when 'ppc64', 'ppc64le'
+  describe command('rpm -qi qemu-kvm-ev | grep Signature') do
+    its(:stdout) { should match(/Key ID 2df30655a70b13b7/) }
+  end
 end
 
 %w(base extras updates).each do |r|


### PR DESCRIPTION
Reverts osuosl-cookbooks/yum-qemu-ev#10

I forgot that we build our own ppc64le builds so that has ceph libraries enabled. Need to revert this.