### PR TITLE
Update ChefSpec platform versions. Add Debian 9

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -8,21 +8,3 @@ CENTOS_7_OPTS = {
   version: '7.4.1708',
   log_level: :fatal,
 }.freeze
-
-CENTOS_6_OPTS = {
-  platform: 'centos',
-  version: '6.9',
-  log_level: :fatal,
-}.freeze
-
-DEBIAN_8_OPTS = {
-  platform: 'debian',
-  version: '8.4',
-  log_level: :fatal,
-}.freeze
-
-DEBIAN_9_OPTS = {
-  platform: 'debian',
-  version: '9.3',
-  log_level: :fatal,
-}.freeze

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -5,18 +5,24 @@ ChefSpec::Coverage.start! { add_filter 'yum-qemu-ev' }
 
 CENTOS_7_OPTS = {
   platform: 'centos',
-  version: '7.2.1511',
+  version: '7.4.1708',
   log_level: :fatal,
 }.freeze
 
 CENTOS_6_OPTS = {
   platform: 'centos',
-  version: '6.8',
+  version: '6.9',
   log_level: :fatal,
 }.freeze
 
 DEBIAN_8_OPTS = {
   platform: 'debian',
   version: '8.4',
+  log_level: :fatal,
+}.freeze
+
+DEBIAN_9_OPTS = {
+  platform: 'debian',
+  version: '9.3',
   log_level: :fatal,
 }.freeze


### PR DESCRIPTION
I left the existing Debian 8 version alone. Should I keep 8.4 or rollback to 8.10?